### PR TITLE
Revert "Upgrade to Ubuntu Focal"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Looks like python-pip doesn't exist anymore in 20.04. It looks like it has been removed from the repositories, hence reverting this PR.